### PR TITLE
Send custom args when building tests

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -59,6 +59,11 @@ pub struct TestOptions {
     #[arg(long, short)]
     pub jobs: Option<usize>,
 
+    /// Argument to forward when building tests
+    #[arg(long, short)]
+    pub build_args: Vec<String>,
+
+    /// Argument to forward when running tests
     #[arg(last = true)]
     pub extra: Vec<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,8 @@ fn compile_tests(command: &Command) -> anyhow::Result<Vec<PathBuf>> {
         cmd = cmd.arg("--release");
     }
 
+    cmd = cmd.args(&command.test_opts.build_args);
+
     let mut out = cmd.stdout(Redirection::Pipe).popen()?;
 
     let stdout = out.stdout.take().context("could not read from stdout")?;


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes N/A

## What does this PR do?
- Add"build-args" arg to send argument when building tests
 Example : Run cargo flaky with some features flag the target : `cargo flaky --build-args '--features' --build-args 'feature1,feature2'` 

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
